### PR TITLE
Refactor: Add TypeScript types to ProjectsSection projects

### DIFF
--- a/components/ProjectsSection.tsx
+++ b/components/ProjectsSection.tsx
@@ -1,11 +1,16 @@
 import React from "react";
 import { Button } from "@/components/ui/button";
 
+interface Project {
+  slug: string;
+  url: string;
+}
+
 const getNameFromSlug = (slug: string) => {
   return slug.replace(/-/g, " ").toUpperCase();
 };
 
-const projects = [
+const projects: Project[] = [
   // Displayed in the order they are listed here
   { slug: "leadpilot", url: "https://leadpilot.com" },
   {


### PR DESCRIPTION
I defined a `Project` interface and applied it to the `projects` array in `components/ProjectsSection.tsx` to improve type safety for you.